### PR TITLE
Beacon Facet

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "lerna run build --no-private",
     "prettier-check": "prettier --check --ignore-unknown '!**/build/**' --ignore-path .gitignore .",
     "prettier-format": "prettier --write --ignore-unknown '!**/build/**' --ignore-path .gitignore .",
-    "lint": "eslint --ignore-path .gitignore . --ignore-pattern '**/node_modules/**' --ignore-pattern '**/build/**'",
+    "lint": "eslint --ignore-path .gitignore . --ignore-pattern '**/node_modules/**' --ignore-pattern '**/build/**' --ignore-pattern '**/dist/**'",
     "lint-fix": "yarn lint --fix",
     "validate": "yarn prettier-check && yarn lint && yarn test && yarn build",
     "validate-fix": "yarn prettier-format && yarn lint-fix && yarn test && yarn build",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@elastic/search-ui": "1.20.2",
+    "@elastic/search-ui": "file:../search-ui",
     "downshift": "^3.2.10",
     "rc-pagination": "^1.20.1",
     "react-select": "^5.0.0"

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
@@ -1,4 +1,12 @@
-@import "../../../../../../../node_modules/rc-pagination/dist/rc-pagination.min";
+/* Use the first import path instead when you are building this package from lerna's root workspace.
+  The import path for the rc-pagination stylesheet could different depending on whether you are building
+  from Lerna's root workspace or from the package directory.
+
+  See this filed issue to track this discussion:
+  https://github.com/elastic/search-ui/issues/978
+*/
+// @import "../../../../../../../node_modules/rc-pagination/dist/rc-pagination.min";
+@import "../../../../../node_modules/rc-pagination/dist/rc-pagination.min";
 @include block("paging") {
   > li {
     border: none;

--- a/packages/react-search-ui-views/src/types/index.ts
+++ b/packages/react-search-ui-views/src/types/index.ts
@@ -1,6 +1,7 @@
 import type {
   FacetValue,
   FieldValue,
+  FilterValue,
   FilterType,
   SearchContextState
 } from "@elastic/search-ui";
@@ -61,6 +62,9 @@ export type {
   SortingViewProps
 } from "../Sorting";
 
+// The type of the `value` parameter for `onRemove`, `onChange`, and `onSelect` should be FilterValue instead of FieldValue.
+// But we will keep it as-is for now until the filed issue gets resolved
+// https://github.com/elastic/search-ui/issues/979
 export type FacetViewProps = {
   className?: string;
   label: string;
@@ -94,6 +98,57 @@ export type FacetContainerProps = BaseContainerProps & {
   field: string;
   label: string;
 } & FacetContainerContext;
+
+export type FacetDefaultOptionProps =
+  | string
+  | {
+      label: string;
+      value: string;
+    };
+
+export type FacetDefaultOptionsProps = {
+  sectionName?: string;
+  options: FacetDefaultOptionProps[];
+};
+
+export type BeaconFacetViewProps = FacetViewProps & {
+  field: string;
+  filterType: FilterType;
+  showDefaultOptionsOnly?: boolean;
+  defaultOptions?: FacetDefaultOptionsProps[];
+  searchTerm: string;
+  facetValuesMap: BeaconFacetValuesMapProps;
+  otherOptionsSectionName?: string | undefined;
+  addFilter: (
+    field: string,
+    value: FilterValue,
+    filterType: FilterType
+  ) => void;
+  removeFilter: (
+    field: string,
+    value: FilterValue,
+    filterType: FilterType
+  ) => void;
+  setFilter: (
+    field: string,
+    value: FilterValue,
+    filterType: FilterType
+  ) => void;
+};
+
+export type BeaconFacetContainerProps = Omit<FacetContainerProps, "view"> & {
+  view?: React.ComponentType<BeaconFacetViewProps>;
+  showDefaultOptionsOnly?: boolean;
+  defaultOptions?: FacetDefaultOptionsProps[];
+  otherOptionsSectionName?: string;
+};
+
+// BeaconFacetValuesMapProps is a nested hashmap of filterType -> field (string) -> stringified FacetValue (string) -> FacetValue.
+// This is used to store the facet values in the BeaconFacetContainer.
+export type BeaconFacetValuesMapProps = Record<
+  FilterType,
+  Record<string, Record<string, FacetValue>>
+>;
 
 // From SO https://stackoverflow.com/a/59071783
 // TS Utility to rename keys in a type

--- a/packages/react-search-ui-views/tsconfig.json
+++ b/packages/react-search-ui-views/tsconfig.json
@@ -14,6 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.@(ts|tsx)",
+    "src/**/*.stories.*",
+    "**/__test*__/"
+  ],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"]
 }

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -34,8 +34,8 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "dependencies": {
-    "@elastic/react-search-ui-views": "1.20.2",
-    "@elastic/search-ui": "1.20.2"
+    "@elastic/react-search-ui-views": "file:../react-search-ui-views",
+    "@elastic/search-ui": "file:../search-ui"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 <= 18",

--- a/packages/react-search-ui/src/SearchProvider.tsx
+++ b/packages/react-search-ui/src/SearchProvider.tsx
@@ -61,6 +61,18 @@ const SearchProvider = ({
     }
   }, [config.autocompleteQuery]);
 
+  // Added by Wentao Xu from SignalFire to enable custom behavior in the fork.
+  // This allows us to dynamically configure URL tracking based on the search state
+  // URL state during the same page session.
+  //
+  // See the filed issue for more details:
+  // https://github.com/elastic/search-ui/issues/606
+  useEffect(() => {
+    if (driverInstance) {
+      driverInstance.setTrackUrlState(config.trackUrlState);
+    }
+  }, [config.trackUrlState]);
+
   // Since driver is initialized in useEffect above, we are waiting
   // to render until the driver is available.
   if (!driverInstance) return null;

--- a/packages/react-search-ui/src/__tests__/SearchProvider.test.tsx
+++ b/packages/react-search-ui/src/__tests__/SearchProvider.test.tsx
@@ -20,7 +20,8 @@ function getMocks() {
   const mockedDriver = Object.assign(driver, {
     tearDown: jest.fn(),
     setSearchQuery: jest.fn(),
-    setAutocompleteQuery: jest.fn()
+    setAutocompleteQuery: jest.fn(),
+    setTrackUrlState: jest.fn()
   });
 
   return {
@@ -72,6 +73,7 @@ describe("SearchProvider", () => {
       updatedSearchQueryConfig
     );
     expect(driver.setAutocompleteQuery).not.toHaveBeenCalled();
+    expect(driver.setTrackUrlState).not.toHaveBeenCalled();
   });
 
   it("will update searchDriver when autocompleteQuery config changes", () => {
@@ -103,6 +105,38 @@ describe("SearchProvider", () => {
       updatedAutocompleteQueryConfig
     );
     expect(driver.setSearchQuery).not.toHaveBeenCalled();
+    expect(driver.setTrackUrlState).not.toHaveBeenCalled();
+  });
+
+  it("will update searchDriver when trackUrlState config changes", () => {
+    const trackUrlStateConfig = true;
+    const updatedTrackUrlStateConfig = false;
+
+    const { driver, apiConnector } = getMocks();
+
+    const wrapper = mount(
+      <SearchProvider
+        driver={driver}
+        config={{
+          apiConnector: apiConnector,
+          trackUrlState: trackUrlStateConfig
+        }}
+      >
+        <div>test</div>
+      </SearchProvider>
+    );
+    expect(driver.setTrackUrlState).not.toHaveBeenCalled();
+
+    wrapper.setProps({
+      driver,
+      config: { trackUrlState: updatedTrackUrlStateConfig }
+    });
+
+    expect(driver.setTrackUrlState).toHaveBeenCalledWith(
+      updatedTrackUrlStateConfig
+    );
+    expect(driver.setSearchQuery).not.toHaveBeenCalled();
+    expect(driver.setAutocompleteQuery).not.toHaveBeenCalled();
   });
 
   it("exposes state and actions to components", () => {

--- a/packages/react-search-ui/src/containers/BeaconFacet.tsx
+++ b/packages/react-search-ui/src/containers/BeaconFacet.tsx
@@ -1,0 +1,263 @@
+/*
+# Overview
+BeaconFacet is SignalFire's customization of the Facet component provided by ElasticSearch.
+
+# Purpose
+The customization allows for the following features:
+
+  1) Negatable Facets - Each facet value can be negated which add a filter to the search query and
+  excludes the negated facet value from the search results. To enable this feature, facet values
+  for both the filter type specified as a parameter and filter type of "none" are passed to the
+  children view. This is different from the original Facet component as it only passes 
+  facet values for the single filter type specified as a parameter to the children view. The access
+  to facet values for the "none" filter type allows the children view to display negatable 
+  facet values with the correct selected state in addition to correctly displaying positive 
+  facet values. Moreover, the component passes several filter state handlers to the children view 
+  so that the children view can handle state updates to both positive and negatable facet values.
+  (See `addFilter`, `removeFilter`, and `setFilter` in the code below.)
+
+  2) Default Options - The component accepts default options as an optional parameter which can
+  be used to display certain facet values. This is useful for curating or highlighting certain facet
+  values for better use experience. The component can also be configured to either display or hide
+  other facet values that are not in the default options list. If the component is configured to
+  display other facet values, it will make sure to prevent displaying duplicate facet values that
+  have already appeared in the default options list.
+
+# Parameters
+Only listing custom parameters introduced in addition to the ones from the original Facet component.
+For the list of original parameters, see the original Facet component.
+- @param {FacetValue[]} defaultOptions - The list of default options to display. If specified, the
+  component will display the default options in the order specified in the lis
+- @param {boolean} showDefaultOptionsOnly - Whether to display only the default options or not. If
+  true, it will hide other facet values that are not in the default options list.
+
+# Implementation Notes
+The foundation of this component is the original Facet component provided by ElasticSearch and the
+code is copied and pasted from that component as a starting point. Then, custom code was written
+to implement the features described above. To keep up with the changes made to the original Facet
+component in future releases, each release should be carefully reviewed and any corresponding
+changes should also be made to this component.  
+*/
+
+import React from "react";
+import { Component } from "react";
+import {
+  FacetContainerContext,
+  BeaconFacetContainerProps,
+  BeaconFacetViewProps,
+  MultiCheckboxFacet,
+  BeaconFacetValuesMapProps
+} from "@elastic/react-search-ui-views";
+import { FacetValue, helpers } from "@elastic/search-ui";
+import {
+  isMatchedFacetValueAndSearchTerm,
+  isMatchedDefaultOptionAndSearchTerm,
+  buildFacetValuesMap,
+  stringifyFilterValue
+} from "../helpers";
+import { withSearch } from "..";
+
+const { markSelectedFacetValuesFromFilters } = helpers;
+
+type FacetContainerState = {
+  searchTerm: string;
+  more: number;
+};
+
+export class BeaconFacetContainer extends Component<
+  BeaconFacetContainerProps,
+  FacetContainerState
+> {
+  static defaultProps = {
+    filterType: "all",
+    isFilterable: false,
+    show: 5
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      more: props.show,
+      searchTerm: ""
+    };
+  }
+
+  handleClickMore = (totalOptions) => {
+    this.setState(({ more }) => {
+      let visibleOptionsCount = more + 10;
+      const showingAll = visibleOptionsCount >= totalOptions;
+      if (showingAll) visibleOptionsCount = totalOptions;
+
+      this.props.a11yNotify("moreFilters", { visibleOptionsCount, showingAll });
+
+      return { more: visibleOptionsCount };
+    });
+  };
+
+  handleFacetSearch = (searchTerm) => {
+    this.setState({ searchTerm });
+  };
+
+  render() {
+    const { more, searchTerm } = this.state;
+    const {
+      addFilter,
+      className,
+      facets,
+      field,
+      filterType,
+      filters,
+      label,
+      removeFilter,
+      setFilter,
+      view,
+      isFilterable,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      a11yNotify,
+      defaultOptions: rawDefaultOptions,
+      showDefaultOptionsOnly,
+      ...rest
+    } = this.props;
+    const facetsForField = facets[field];
+
+    if (!facetsForField) return null;
+
+    // By using `[0]`, we are currently assuming only 1 facet per field. This will likely be enforced
+    // in future version, so instead of an array, there will only be one facet allowed per field.
+    const facet = facetsForField[0];
+
+    // Build facetValuesMap for both the specified filterType and "none" filterType. This will
+    // get passed to the children view so that the children view can display both positive and
+    // negatable facet values.
+    const facetValuesMap = {
+      [filterType]: {},
+      none: {}
+    } as BeaconFacetValuesMapProps;
+
+    [filterType, "none"].forEach((_filterType) => {
+      const facetValues = markSelectedFacetValuesFromFilters(
+        facet,
+        filters,
+        field,
+        _filterType
+      ).data;
+
+      if (!facetValues.length) {
+        facetValuesMap[_filterType][field] = {};
+      } else {
+        facetValuesMap[_filterType][field] = buildFacetValuesMap(facetValues);
+      }
+    });
+
+    // Initialize facetValues for the specified filterType.
+    let facetValues = Object.values(facetValuesMap[filterType][field]);
+
+    // Initialize selectedValues
+    const selectedValues = facetValues
+      .filter((fv) => fv.selected)
+      .map((fv) => fv.value);
+
+    // Initialize defaultOptions
+    let defaultOptions = rawDefaultOptions;
+
+    // Return null early if there are no facetValues, selectedValues, and defaultOptions.
+    if (
+      !facetValues.length &&
+      !selectedValues.length &&
+      !defaultOptions.length
+    ) {
+      return null;
+    }
+
+    // If searchTerm exists, filter down facetValues and defaultOptions.
+    const searchTermTrimmed = searchTerm.trim();
+    if (searchTermTrimmed) {
+      // Filter down facetValues by searchTerm
+      facetValues = facetValues.filter((facetValue: FacetValue) =>
+        isMatchedFacetValueAndSearchTerm(facetValue, searchTermTrimmed)
+      );
+
+      // Filter down defaultOptions by searchTerm
+      if (defaultOptions && defaultOptions.length) {
+        const filteredDefaultOptions = [];
+        defaultOptions.forEach((section) => {
+          const sectionOptions = section.options.filter((option) =>
+            isMatchedDefaultOptionAndSearchTerm(option, searchTerm)
+          );
+          if (sectionOptions && sectionOptions.length) {
+            filteredDefaultOptions.push({
+              ...section,
+              options: sectionOptions
+            });
+          }
+        });
+        defaultOptions = filteredDefaultOptions;
+      }
+    }
+
+    // Remove values that are already part of the default options from the other facet values to
+    // prevent any duplicates.
+    if (!showDefaultOptionsOnly && defaultOptions && defaultOptions.length) {
+      const defaultOptionsSet = new Set(
+        defaultOptions.flatMap((section) =>
+          section.options.map((option) =>
+            typeof option === "string" ? option : option.value
+          )
+        )
+      );
+      facetValues = facetValues.filter(
+        (facetValue: FacetValue) =>
+          !defaultOptionsSet.has(stringifyFilterValue(facetValue.value))
+      );
+    }
+
+    const View: React.ComponentType<BeaconFacetViewProps> =
+      view || MultiCheckboxFacet;
+
+    const viewProps: BeaconFacetViewProps = {
+      className,
+      label: label,
+      field,
+      filterType,
+      onMoreClick: this.handleClickMore.bind(this, facetValues.length),
+      onRemove: (value) => {
+        removeFilter(field, value, filterType);
+      },
+      onChange: (value) => {
+        setFilter(field, value, filterType);
+      },
+      onSelect: (value) => {
+        addFilter(field, value, filterType);
+      },
+      options: facetValues.slice(0, more),
+      showMore: facetValues.length > more,
+      values: selectedValues,
+      showSearch: isFilterable,
+      onSearch: (value) => {
+        this.handleFacetSearch(value);
+      },
+      searchPlaceholder: `Filter ${label}`,
+      searchTerm,
+      addFilter,
+      removeFilter,
+      setFilter,
+      defaultOptions,
+      showDefaultOptionsOnly,
+      facetValuesMap,
+      ...rest
+    };
+
+    return <View {...viewProps} />;
+  }
+}
+
+export default withSearch<BeaconFacetContainerProps, FacetContainerContext>(
+  ({ filters, facets, addFilter, removeFilter, setFilter, a11yNotify }) => ({
+    filters,
+    facets,
+    addFilter,
+    removeFilter,
+    setFilter,
+    a11yNotify
+  })
+)(BeaconFacetContainer);

--- a/packages/react-search-ui/src/containers/index.ts
+++ b/packages/react-search-ui/src/containers/index.ts
@@ -1,3 +1,4 @@
+export { default as BeaconFacet } from "./BeaconFacet";
 export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as Facet } from "./Facet";
 export { default as Paging } from "./Paging";

--- a/packages/react-search-ui/src/helpers.ts
+++ b/packages/react-search-ui/src/helpers.ts
@@ -1,6 +1,88 @@
+import { FacetValue, FilterValue, FilterType } from "@elastic/search-ui";
+import {
+  FacetDefaultOptionProps,
+  BeaconFacetValuesMapProps
+} from "@elastic/react-search-ui-views";
+
 // LÒpez => Lopez
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
 export const accentFold = (str: any): string =>
   typeof str === "string"
     ? str.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
     : "";
+
+export function getValueToSearchFromFacetValue(facetValue: FacetValue): string {
+  switch (typeof facetValue.value) {
+    case "string":
+      return accentFold(facetValue.value).toLowerCase();
+    case "number":
+      return facetValue.value.toString();
+    case "object": {
+      return "name" in facetValue.value
+        ? accentFold(facetValue.value.name).toLowerCase()
+        : "";
+    }
+    default:
+      return "";
+  }
+}
+
+export function isMatchedFacetValueAndSearchTerm(
+  facetValue: FacetValue,
+  searchTerm: string
+) {
+  const valueToSearch = getValueToSearchFromFacetValue(facetValue);
+  return valueToSearch.includes(accentFold(searchTerm).toLowerCase());
+}
+
+export function isMatchedDefaultOptionAndSearchTerm(
+  option: FacetDefaultOptionProps,
+  searchTerm: string
+) {
+  const valueToSearch =
+    typeof option === "string"
+      ? accentFold(option).toLowerCase()
+      : accentFold(option.value).toLowerCase();
+
+  return valueToSearch.includes(accentFold(searchTerm).toLowerCase());
+}
+
+/* 
+Stringify the filterValue which can be a string, number, boolean, object with a name property,
+or an array of string, number, or boolean. This is helpful for building keys to be used in hashmaps
+of facetValues.
+*/
+export const stringifyFilterValue = (filterValue: FilterValue): string => {
+  if (typeof filterValue === "string") return filterValue;
+  if (typeof filterValue === "number" || typeof filterValue === "boolean")
+    return filterValue.toString();
+  if (typeof filterValue === "object" && "name" in filterValue)
+    return filterValue.name;
+  return "";
+};
+
+/*
+Retrieves the stored facetValue from the facetValueMap given that map and the required keys of
+filterType, field, and filterValue.
+*/
+export const getFacetValueFromFacetValueMap = (
+  facetValueMap: BeaconFacetValuesMapProps,
+  filterType: FilterType,
+  field: string,
+  filterValue: FilterValue
+): FacetValue => {
+  const filterValueString = stringifyFilterValue(filterValue);
+  return facetValueMap?.[filterType]?.[field]?.[filterValueString];
+};
+
+/**
+ * Build a hashmap of facetValues keyed by their stringified value.
+ */
+export function buildFacetValuesMap(
+  facetValues: FacetValue[]
+): Record<string, FacetValue> {
+  return facetValues.reduce((acc, facetValue) => {
+    acc[stringifyFilterValue(facetValue.value)] = facetValue;
+    return acc;
+  }, {});
+}

--- a/packages/react-search-ui/src/index.ts
+++ b/packages/react-search-ui/src/index.ts
@@ -4,3 +4,4 @@ export { default as WithSearch } from "./WithSearchRenderProps";
 export { default as SearchProvider } from "./SearchProvider";
 
 export * from "./containers";
+export * from "./helpers";

--- a/packages/react-search-ui/tsconfig.json
+++ b/packages/react-search-ui/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"]
 }

--- a/packages/react-search-ui/tsconfig.json
+++ b/packages/react-search-ui/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "target": "es2015",
+    "lib": ["es2020", "dom"],
     "declaration": true,
     "outDir": "lib/esm",
     "allowJs": true,

--- a/packages/search-ui-analytics-plugin/package.json
+++ b/packages/search-ui-analytics-plugin/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "devDependencies": {
-    "@elastic/search-ui": "1.20.2",
+    "@elastic/search-ui": "file:../search-ui",
     "typescript": "^4.5.4"
   },
   "publishConfig": {

--- a/packages/search-ui-analytics-plugin/tsconfig.json
+++ b/packages/search-ui-analytics-plugin/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "@elastic/app-search-javascript": "^8.1.2",
-    "@elastic/search-ui": "1.20.2"
+    "@elastic/search-ui": "file:../search-ui"
   }
 }

--- a/packages/search-ui-app-search-connector/tsconfig.json
+++ b/packages/search-ui-app-search-connector/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "^8.2.1",
-    "@elastic/search-ui": "1.20.2",
+    "@elastic/search-ui": "file:../search-ui",
     "@searchkit/sdk": "^3.0.0"
   }
 }

--- a/packages/search-ui-elasticsearch-connector/tsconfig.json
+++ b/packages/search-ui-elasticsearch-connector/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -42,7 +42,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@elastic/search-ui": "1.20.2",
+    "@elastic/search-ui": "file:../search-ui",
     "@searchkit/sdk": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/search-ui-engines-connector/tsconfig.json
+++ b/packages/search-ui-engines-connector/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -38,6 +38,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@elastic/search-ui": "1.20.2"
+    "@elastic/search-ui": "file:../search-ui"
   }
 }

--- a/packages/search-ui-site-search-connector/tsconfig.json
+++ b/packages/search-ui-site-search-connector/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui-workplace-search-connector/package.json
+++ b/packages/search-ui-workplace-search-connector/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@elastic/search-ui": "1.20.2",
+    "@elastic/search-ui": "file:../search-ui",
     "query-string": "^7.1.1"
   }
 }

--- a/packages/search-ui-workplace-search-connector/tsconfig.json
+++ b/packages/search-ui-workplace-search-connector/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.@(ts|tsx)", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -503,6 +503,9 @@ class SearchDriver {
             return;
           }
 
+          // Swallow error caused by an old request to prevent disruption of newer requests
+          // See https://github.com/elastic/search-ui/issues/981
+          if (this.searchRequestSequencer.isOldRequest(requestId)) return;
           this._setState({
             error: `An unexpected error occurred: ${error.message}`
           });

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -548,6 +548,13 @@ class SearchDriver {
   }
 
   /**
+   * @param bool trackUrlState
+   */
+  setTrackUrlState(trackUrlState: boolean): void {
+    this.trackUrlState = trackUrlState;
+  }
+
+  /**
    * Any time state is updated in this Driver, the provided callback
    * will be executed with the updated state.
    *

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -228,20 +228,7 @@ class SearchDriver {
     this.urlPushDebounceLength = urlPushDebounceLength;
     this.alwaysSearchOnInitialLoad = alwaysSearchOnInitialLoad;
     this.apiConnector = apiConnector;
-
-    let urlState;
-    if (trackUrlState) {
-      this.URLManager = new URLManager(routingOptions);
-      urlState = this.URLManager.getStateFromURL();
-      this.URLManager.onURLStateChange((urlState) => {
-        this._updateSearchResults(
-          { ...DEFAULT_STATE, ...urlState },
-          { skipPushToUrl: true }
-        );
-      });
-    } else {
-      urlState = {};
-    }
+    this.URLManager = new URLManager(routingOptions);
 
     // Manage screen reader accessible notifications
     this.hasA11yNotifications = hasA11yNotifications;
@@ -258,6 +245,9 @@ class SearchDriver {
       ...this.state,
       ...initialState
     };
+
+    // Get RequestState from the URL if trackUrlState config is enabled
+    const urlState = trackUrlState ? this.URLManager.getStateFromURL() : {};
 
     // We filter these here to disallow anything other than valid search
     // parameters to be passed in initial state, or url state. `results`, etc,

--- a/packages/search-ui/tsconfig.json
+++ b/packages/search-ui/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/test/**/*", "**/__test*__/"],
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,6 +1701,22 @@
     uuid "^8.3.0"
     vfile "^4.2.0"
 
+"@elastic/react-search-ui-views@file:packages/react-search-ui-views":
+  version "1.20.2"
+  dependencies:
+    "@elastic/search-ui" "1.20.2"
+    downshift "^3.2.10"
+    rc-pagination "^1.20.1"
+    react-select "^5.0.0"
+
+"@elastic/search-ui@file:packages/search-ui":
+  version "1.20.2"
+  dependencies:
+    date-fns "^1.30.1"
+    deep-equal "^1.0.1"
+    history "^4.9.0"
+    qs "^6.7.0"
+
 "@elastic/transport@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.2.0.tgz#f292cb79c918a36268dd853431e41f13544814ad"


### PR DESCRIPTION
This PR forks off from Elastic's latest search-ui package (v1.20.0) and introduces the following changes:

- Changes to make this repo import / build setting to enable being used as a submodule 
- Support for dynamic URL tracking
- `BeaconFacet` component that supports defaultOptions and negatable facet value
- Bug fix to prevent redundant search request 

Related PR:
https://github.com/Tsquare/beacon/pull/3172