### PR TITLE
Fix Unlisten

### DIFF
--- a/packages/search-ui/src/URLManager.ts
+++ b/packages/search-ui/src/URLManager.ts
@@ -247,7 +247,7 @@ export default class URLManager {
     return this.history.listen(handler);
   }
 
-  tearDown(): void {
-    this.unlisten();
+  tearDown = () => {
+    this.unlisten?.();
   }
 }


### PR DESCRIPTION
Lots of recent sentry errors corresponding to `this.unlisten is not a function` – I think this is happening because [onURLStateChange](https://github.com/Tsquare/search-ui/blob/03bb7313771cb695308dcae3fbabe47d6c754dc3/packages/search-ui/src/URLManager.ts#L229) never fires deep inside of elastic UI – add an optional call to the fn to resolve this

https://github.com/Tsquare/beacon/pull/3187