### PR TITLE
State Code Filtering

### DIFF
--- a/packages/react-search-ui-views/src/Autocomplete.tsx
+++ b/packages/react-search-ui-views/src/Autocomplete.tsx
@@ -36,7 +36,7 @@ function getSuggestionTitle(suggestionType, autocompleteSuggestions) {
 function getSuggestionDisplayField(
   suggestionType: string,
   autocompleteSuggestions: AutocompleteSuggestion
-): string | undefined {
+): string {
   if (autocompleteSuggestions.queryType === "results") {
     return autocompleteSuggestions.displayField as string;
   }
@@ -55,12 +55,12 @@ export type SearchBoxAutocompleteViewProps = {
   autocompletedSuggestions: AutocompletedSuggestions;
   autocompletedSuggestionsCount: number;
   autocompleteSuggestions?: boolean | AutocompleteSuggestion;
-  getItemProps: (p: {
-    key?: string;
-    index: number;
-    item: AutocompletedSuggestion;
+  getItemProps: ({
+    key: string,
+    index: number,
+    item: AutocompletedSuggestion
   }) => any;
-  getMenuProps: (p: { className: string }) => any;
+  getMenuProps: ({ className: string }) => any;
   className?: string;
 };
 
@@ -111,27 +111,25 @@ function Autocomplete({
                         ) => {
                           index++;
                           if (suggestion.queryType === "results") {
-                            let displayField: string | null = null;
+                            let displayField = null;
                             if (autocompleteSuggestions === true) {
                               displayField = Object.keys(suggestion.result)[0];
                             } else {
-                              displayField =
-                                getSuggestionDisplayField(
-                                  suggestionType,
-                                  autocompleteSuggestions
-                                ) ?? null;
+                              displayField = getSuggestionDisplayField(
+                                suggestionType,
+                                autocompleteSuggestions
+                              );
                             }
-                            const suggestionValue = displayField
-                              ? suggestion.result[displayField]?.raw
-                              : undefined;
+                            const suggestionValue =
+                              suggestion.result[displayField]?.raw;
 
                             return (
                               <li
                                 {...getItemProps({
-                                  key: suggestionValue?.toString(),
+                                  key: suggestionValue,
                                   index: index - 1,
                                   item: {
-                                    suggestion: suggestionValue?.toString()
+                                    suggestion: suggestionValue
                                   }
                                 })}
                                 data-transaction-name="query suggestion"
@@ -150,7 +148,7 @@ function Autocomplete({
                                 item: {
                                   ...suggestion,
                                   index: index - 1
-                                } as any
+                                }
                               })}
                               data-transaction-name="query suggestion"
                             >

--- a/packages/react-search-ui-views/src/Autocomplete.tsx
+++ b/packages/react-search-ui-views/src/Autocomplete.tsx
@@ -36,7 +36,7 @@ function getSuggestionTitle(suggestionType, autocompleteSuggestions) {
 function getSuggestionDisplayField(
   suggestionType: string,
   autocompleteSuggestions: AutocompleteSuggestion
-): string {
+): string | undefined {
   if (autocompleteSuggestions.queryType === "results") {
     return autocompleteSuggestions.displayField as string;
   }
@@ -55,12 +55,12 @@ export type SearchBoxAutocompleteViewProps = {
   autocompletedSuggestions: AutocompletedSuggestions;
   autocompletedSuggestionsCount: number;
   autocompleteSuggestions?: boolean | AutocompleteSuggestion;
-  getItemProps: ({
-    key: string,
-    index: number,
-    item: AutocompletedSuggestion
+  getItemProps: (p: {
+    key?: string;
+    index: number;
+    item: AutocompletedSuggestion;
   }) => any;
-  getMenuProps: ({ className: string }) => any;
+  getMenuProps: (p: { className: string }) => any;
   className?: string;
 };
 
@@ -111,25 +111,27 @@ function Autocomplete({
                         ) => {
                           index++;
                           if (suggestion.queryType === "results") {
-                            let displayField = null;
+                            let displayField: string | null = null;
                             if (autocompleteSuggestions === true) {
                               displayField = Object.keys(suggestion.result)[0];
                             } else {
-                              displayField = getSuggestionDisplayField(
-                                suggestionType,
-                                autocompleteSuggestions
-                              );
+                              displayField =
+                                getSuggestionDisplayField(
+                                  suggestionType,
+                                  autocompleteSuggestions
+                                ) ?? null;
                             }
-                            const suggestionValue =
-                              suggestion.result[displayField]?.raw;
+                            const suggestionValue = displayField
+                              ? suggestion.result[displayField]?.raw
+                              : undefined;
 
                             return (
                               <li
                                 {...getItemProps({
-                                  key: suggestionValue,
+                                  key: suggestionValue?.toString(),
                                   index: index - 1,
                                   item: {
-                                    suggestion: suggestionValue
+                                    suggestion: suggestionValue?.toString()
                                   }
                                 })}
                                 data-transaction-name="query suggestion"
@@ -148,7 +150,7 @@ function Autocomplete({
                                 item: {
                                   ...suggestion,
                                   index: index - 1
-                                }
+                                } as any
                               })}
                               data-transaction-name="query suggestion"
                             >

--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.tsx
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.tsx
@@ -4,18 +4,20 @@ import { appendClassName, getFilterValueDisplay } from "./view-helpers";
 import { FacetViewProps } from "./types";
 import type { FieldValue } from "@elastic/search-ui";
 
-function MultiCheckboxFacet({
-  className,
-  label,
-  onMoreClick,
-  onRemove,
-  onSelect,
-  options,
-  showMore,
-  showSearch,
-  onSearch,
-  searchPlaceholder
-}: FacetViewProps) {
+function MultiCheckboxFacet(props: FacetViewProps) {
+  const {
+    className,
+    label,
+    onMoreClick,
+    onRemove,
+    onSelect,
+    options,
+    showMore,
+    showSearch,
+    onSearch,
+    searchPlaceholder
+  } = props;
+
   return (
     <fieldset className={appendClassName("sui-facet", className)}>
       <legend className="sui-facet__title">{label}</legend>
@@ -60,10 +62,10 @@ function MultiCheckboxFacet({
                 <span className="sui-multi-checkbox-facet__input-text">
                   {getFilterValueDisplay(option.value)}
                 </span>
+                <span className="sui-multi-checkbox-facet__option-count">
+                  {option.count.toLocaleString("en")}
+                </span>
               </div>
-              <span className="sui-multi-checkbox-facet__option-count">
-                {option.count.toLocaleString("en")}
-              </span>
             </label>
           );
         })}

--- a/packages/react-search-ui-views/src/Paging.tsx
+++ b/packages/react-search-ui-views/src/Paging.tsx
@@ -26,7 +26,7 @@ export type PagingContainerProps = BaseContainerProps &
 function Paging({
   className,
   current,
-  resultsPerPage = 0,
+  resultsPerPage,
   onChange,
   totalPages,
   ...rest

--- a/packages/react-search-ui-views/src/Paging.tsx
+++ b/packages/react-search-ui-views/src/Paging.tsx
@@ -26,7 +26,7 @@ export type PagingContainerProps = BaseContainerProps &
 function Paging({
   className,
   current,
-  resultsPerPage,
+  resultsPerPage = 0,
   onChange,
   totalPages,
   ...rest

--- a/packages/react-search-ui-views/src/Result.tsx
+++ b/packages/react-search-ui-views/src/Result.tsx
@@ -45,12 +45,13 @@ function Result({
   ...rest
 }: ResultViewProps) {
   const fields = formatResult(result);
-  const title = getEscapedField(result[titleField]);
-  const url = getUrlSanitizer(URL, location.href)(getRaw(result[urlField]));
-  const thumbnail = getUrlSanitizer(
-    URL,
-    location.href
-  )(getRaw(result[thumbnailField]));
+  const title = titleField ? getEscapedField(result[titleField]) : "";
+  const url = urlField
+    ? getUrlSanitizer(URL, location.href)(getRaw(result[urlField]))
+    : "";
+  const thumbnail = thumbnailField
+    ? getUrlSanitizer(URL, location.href)(getRaw(result[thumbnailField]))
+    : "";
 
   return (
     <li className={appendClassName("sui-result", className)} {...rest}>

--- a/packages/react-search-ui-views/src/Result.tsx
+++ b/packages/react-search-ui-views/src/Result.tsx
@@ -45,13 +45,12 @@ function Result({
   ...rest
 }: ResultViewProps) {
   const fields = formatResult(result);
-  const title = titleField ? getEscapedField(result[titleField]) : "";
-  const url = urlField
-    ? getUrlSanitizer(URL, location.href)(getRaw(result[urlField]))
-    : "";
-  const thumbnail = thumbnailField
-    ? getUrlSanitizer(URL, location.href)(getRaw(result[thumbnailField]))
-    : "";
+  const title = getEscapedField(result[titleField]);
+  const url = getUrlSanitizer(URL, location.href)(getRaw(result[urlField]));
+  const thumbnail = getUrlSanitizer(
+    URL,
+    location.href
+  )(getRaw(result[thumbnailField]));
 
   return (
     <li className={appendClassName("sui-result", className)} {...rest}>

--- a/packages/react-search-ui-views/src/ResultsPerPage.tsx
+++ b/packages/react-search-ui-views/src/ResultsPerPage.tsx
@@ -53,13 +53,12 @@ function ResultsPerPage({
   value: selectedValue,
   ...rest
 }: ResultsPerPageViewProps) {
-  const selectedOption = selectedValue ? wrapOption(selectedValue) : null;
+  let selectedOption = null;
+
   if (selectedValue) {
-    if (!options) {
-      options = [selectedValue];
-    } else if (!options.includes(selectedValue)) {
-      options = [selectedValue, ...options];
-    }
+    selectedOption = wrapOption(selectedValue);
+
+    if (!options.includes(selectedValue)) options = [selectedValue, ...options];
   }
 
   return (
@@ -72,8 +71,8 @@ function ResultsPerPage({
         className="sui-select sui-select--inline"
         classNamePrefix="sui-select"
         value={selectedOption}
-        onChange={(o) => o !== null && onChange(o.value)}
-        options={options?.map(wrapOption)}
+        onChange={(o) => onChange(o.value)}
+        options={options.map(wrapOption)}
         isSearchable={false}
         styles={setDefaultStyle}
         components={{

--- a/packages/react-search-ui-views/src/ResultsPerPage.tsx
+++ b/packages/react-search-ui-views/src/ResultsPerPage.tsx
@@ -53,12 +53,13 @@ function ResultsPerPage({
   value: selectedValue,
   ...rest
 }: ResultsPerPageViewProps) {
-  let selectedOption = null;
-
+  const selectedOption = selectedValue ? wrapOption(selectedValue) : null;
   if (selectedValue) {
-    selectedOption = wrapOption(selectedValue);
-
-    if (!options.includes(selectedValue)) options = [selectedValue, ...options];
+    if (!options) {
+      options = [selectedValue];
+    } else if (!options.includes(selectedValue)) {
+      options = [selectedValue, ...options];
+    }
   }
 
   return (
@@ -71,8 +72,8 @@ function ResultsPerPage({
         className="sui-select sui-select--inline"
         classNamePrefix="sui-select"
         value={selectedOption}
-        onChange={(o) => onChange(o.value)}
-        options={options.map(wrapOption)}
+        onChange={(o) => o !== null && onChange(o.value)}
+        options={options?.map(wrapOption)}
         isSearchable={false}
         styles={setDefaultStyle}
         components={{

--- a/packages/react-search-ui-views/src/SearchInput.tsx
+++ b/packages/react-search-ui-views/src/SearchInput.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { ReactNode } from "react";
 
 export type InputViewProps = {
-  getAutocomplete: () => JSX.Element;
+  getAutocomplete: () => ReactNode;
   getButtonProps: (additionalProps?: any) => any;
   getInputProps: (additionalProps?: any) => any;
 };

--- a/packages/react-search-ui-views/src/SearchInput.tsx
+++ b/packages/react-search-ui-views/src/SearchInput.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from "react";
+import React from "react";
 
 export type InputViewProps = {
-  getAutocomplete: () => ReactNode;
+  getAutocomplete: () => JSX.Element;
   getButtonProps: (additionalProps?: any) => any;
   getInputProps: (additionalProps?: any) => any;
 };

--- a/packages/react-search-ui-views/src/SingleSelectFacet.tsx
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.tsx
@@ -69,7 +69,7 @@ function SingleSelectFacet({
           }
         }}
         value={selectedSelectBoxOption}
-        onChange={(o) => o !== null && onChange(o.value)}
+        onChange={(o) => onChange(o.value)}
         options={selectBoxOptions}
         isSearchable={false}
         styles={setDefaultStyle}

--- a/packages/react-search-ui-views/src/SingleSelectFacet.tsx
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.tsx
@@ -69,7 +69,7 @@ function SingleSelectFacet({
           }
         }}
         value={selectedSelectBoxOption}
-        onChange={(o) => onChange(o.value)}
+        onChange={(o) => o !== null && onChange(o.value)}
         options={selectBoxOptions}
         isSearchable={false}
         styles={setDefaultStyle}

--- a/packages/react-search-ui-views/src/Sorting.tsx
+++ b/packages/react-search-ui-views/src/Sorting.tsx
@@ -59,7 +59,7 @@ function Sorting({
         className="sui-select"
         classNamePrefix="sui-select"
         value={selectedOption}
-        onChange={(o) => onChange(o.value)}
+        onChange={(o) => o !== null && onChange(o.value)}
         options={options}
         isSearchable={false}
         styles={setDefaultStyle}

--- a/packages/react-search-ui-views/src/Sorting.tsx
+++ b/packages/react-search-ui-views/src/Sorting.tsx
@@ -59,7 +59,7 @@ function Sorting({
         className="sui-select"
         classNamePrefix="sui-select"
         value={selectedOption}
-        onChange={(o) => o !== null && onChange(o.value)}
+        onChange={(o) => onChange(o.value)}
         options={options}
         isSearchable={false}
         styles={setDefaultStyle}

--- a/packages/react-search-ui-views/src/types/index.ts
+++ b/packages/react-search-ui-views/src/types/index.ts
@@ -119,6 +119,7 @@ export type BeaconFacetViewProps = FacetViewProps & {
   searchTerm: string;
   facetValuesMap: BeaconFacetValuesMapProps;
   otherOptionsSectionName?: string | undefined;
+  optionLabelsMap?: Record<string, string>;
   addFilter: (
     field: string,
     value: FilterValue,
@@ -141,6 +142,7 @@ export type BeaconFacetContainerProps = Omit<FacetContainerProps, "view"> & {
   showDefaultOptionsOnly?: boolean;
   defaultOptions?: FacetDefaultOptionsProps[];
   otherOptionsSectionName?: string;
+  optionLabelsMap?: Record<string, string>;
 };
 
 // BeaconFacetValuesMapProps is a nested hashmap of filterType -> field (string) -> stringified FacetValue (string) -> FacetValue.

--- a/packages/react-search-ui-views/src/types/index.ts
+++ b/packages/react-search-ui-views/src/types/index.ts
@@ -5,6 +5,7 @@ import type {
   FilterType,
   SearchContextState
 } from "@elastic/search-ui";
+import { ReactNode } from "react";
 
 export interface BaseContainerProps {
   children?: React.ReactNode;
@@ -119,7 +120,7 @@ export type BeaconFacetViewProps = FacetViewProps & {
   searchTerm: string;
   facetValuesMap: BeaconFacetValuesMapProps;
   otherOptionsSectionName?: string | undefined;
-  optionLabelsMap?: Record<string, string>;
+  optionLabelsMap?: Record<string, ReactNode>;
   addFilter: (
     field: string,
     value: FilterValue,
@@ -142,7 +143,7 @@ export type BeaconFacetContainerProps = Omit<FacetContainerProps, "view"> & {
   showDefaultOptionsOnly?: boolean;
   defaultOptions?: FacetDefaultOptionsProps[];
   otherOptionsSectionName?: string;
-  optionLabelsMap?: Record<string, string>;
+  optionLabelsMap?: Record<string, ReactNode>;
 };
 
 // BeaconFacetValuesMapProps is a nested hashmap of filterType -> field (string) -> stringified FacetValue (string) -> FacetValue.

--- a/packages/react-search-ui-views/src/view-helpers/appendClassName.ts
+++ b/packages/react-search-ui-views/src/view-helpers/appendClassName.ts
@@ -5,8 +5,8 @@ function getNewClassName(newClassName: string | string[]) {
 }
 
 export default function appendClassName(
-  baseClassName?: string | string[] | undefined,
-  newClassName?: string | string[] | undefined
+  baseClassName?: string | string[] | undefined | null,
+  newClassName?: string | string[] | undefined | null
 ): string {
   if (!newClassName)
     return (

--- a/packages/react-search-ui-views/src/view-helpers/appendClassName.ts
+++ b/packages/react-search-ui-views/src/view-helpers/appendClassName.ts
@@ -5,8 +5,8 @@ function getNewClassName(newClassName: string | string[]) {
 }
 
 export default function appendClassName(
-  baseClassName?: string | string[] | undefined | null,
-  newClassName?: string | string[] | undefined | null
+  baseClassName?: string | string[] | undefined,
+  newClassName?: string | string[] | undefined
 ): string {
   if (!newClassName)
     return (

--- a/packages/react-search-ui/src/containers/BeaconFacet.tsx
+++ b/packages/react-search-ui/src/containers/BeaconFacet.tsx
@@ -175,18 +175,20 @@ export class BeaconFacetContainer extends Component<
     if (searchTermTrimmed) {
       // Filter down facetValues by searchTerm
       facetValues = facetValues.filter((facetValue: FacetValue) => {
-        // Can only reference optionLabelsMap if
-        // optionLabelsMap is returning a string (as opposed to a ReactNode, which we support)
-        if (optionLabelsMap && (
-          typeof facetValue.value === 'string' || typeof facetValue.value === 'number'
-        )) {
-          return isMatchedFacetValueAndSearchTerm(
-            {
-              ...facetValue,
-              value: optionLabelsMap[facetValue.value.toString()]
-            },
-            searchTermTrimmed
-          );
+        if (optionLabelsMap) {
+          const optionLabel = optionLabelsMap[facetValue.value.toString()];
+          // Can only reference optionLabelsMap if
+          // optionLabelsMap is returning a string (as opposed to a ReactNode, which we support)
+          // Otherwise we can't text match against it
+          if (optionLabel !== undefined && typeof optionLabel === 'string' || typeof optionLabel === 'number') {
+            return isMatchedFacetValueAndSearchTerm(
+              {
+                ...facetValue,
+                value: optionLabel.toString()
+              },
+              searchTermTrimmed
+            );
+          }
         }
         return isMatchedFacetValueAndSearchTerm(facetValue, searchTermTrimmed);
       });

--- a/packages/react-search-ui/src/containers/BeaconFacet.tsx
+++ b/packages/react-search-ui/src/containers/BeaconFacet.tsx
@@ -175,7 +175,11 @@ export class BeaconFacetContainer extends Component<
     if (searchTermTrimmed) {
       // Filter down facetValues by searchTerm
       facetValues = facetValues.filter((facetValue: FacetValue) => {
-        if (optionLabelsMap) {
+        // Can only reference optionLabelsMap if
+        // optionLabelsMap is returning a string (as opposed to a ReactNode, which we support)
+        if (optionLabelsMap && (
+          typeof facetValue.value === 'string' || typeof facetValue.value === 'number'
+        )) {
           return isMatchedFacetValueAndSearchTerm(
             {
               ...facetValue,

--- a/packages/react-search-ui/src/containers/BeaconFacet.tsx
+++ b/packages/react-search-ui/src/containers/BeaconFacet.tsx
@@ -116,6 +116,7 @@ export class BeaconFacetContainer extends Component<
       a11yNotify,
       defaultOptions: rawDefaultOptions,
       showDefaultOptionsOnly,
+      optionLabelsMap,
       ...rest
     } = this.props;
     const facetsForField = facets[field];
@@ -173,9 +174,18 @@ export class BeaconFacetContainer extends Component<
     const searchTermTrimmed = searchTerm.trim();
     if (searchTermTrimmed) {
       // Filter down facetValues by searchTerm
-      facetValues = facetValues.filter((facetValue: FacetValue) =>
-        isMatchedFacetValueAndSearchTerm(facetValue, searchTermTrimmed)
-      );
+      facetValues = facetValues.filter((facetValue: FacetValue) => {
+        if (optionLabelsMap) {
+          return isMatchedFacetValueAndSearchTerm(
+            {
+              ...facetValue,
+              value: optionLabelsMap[facetValue.value.toString()]
+            },
+            searchTermTrimmed
+          );
+        }
+        return isMatchedFacetValueAndSearchTerm(facetValue, searchTermTrimmed);
+      });
 
       // Filter down defaultOptions by searchTerm
       if (defaultOptions && defaultOptions.length) {
@@ -234,6 +244,7 @@ export class BeaconFacetContainer extends Component<
       values: selectedValues,
       showSearch: isFilterable,
       onSearch: (value) => {
+        // this method / handleFacetSearch
         this.handleFacetSearch(value);
       },
       searchPlaceholder: `Filter ${label}`,
@@ -244,6 +255,7 @@ export class BeaconFacetContainer extends Component<
       defaultOptions,
       showDefaultOptionsOnly,
       facetValuesMap,
+      optionLabelsMap,
       ...rest
     };
 

--- a/packages/search-ui/src/Events.ts
+++ b/packages/search-ui/src/Events.ts
@@ -82,20 +82,20 @@ class Events {
     onAutocompleteResultClick,
     plugins = []
   }: EventOptions = {}) {
-    this.search = wireUpEventHandler("onSearch", apiConnector, onSearch);
+    this.search = wireUpEventHandler("onSearch", apiConnector!, onSearch);
     this.autocomplete = wireUpEventHandler(
       "onAutocomplete",
-      apiConnector,
+      apiConnector!,
       onAutocomplete
     );
     this.resultClick = wireUpEventHandler(
       "onResultClick",
-      apiConnector,
+      apiConnector!,
       onResultClick
     );
     this.autocompleteResultClick = wireUpEventHandler(
       "onAutocompleteResultClick",
-      apiConnector,
+      apiConnector!,
       onAutocompleteResultClick
     );
     this.plugins = plugins;

--- a/packages/search-ui/src/Events.ts
+++ b/packages/search-ui/src/Events.ts
@@ -82,20 +82,20 @@ class Events {
     onAutocompleteResultClick,
     plugins = []
   }: EventOptions = {}) {
-    this.search = wireUpEventHandler("onSearch", apiConnector!, onSearch);
+    this.search = wireUpEventHandler("onSearch", apiConnector, onSearch);
     this.autocomplete = wireUpEventHandler(
       "onAutocomplete",
-      apiConnector!,
+      apiConnector,
       onAutocomplete
     );
     this.resultClick = wireUpEventHandler(
       "onResultClick",
-      apiConnector!,
+      apiConnector,
       onResultClick
     );
     this.autocompleteResultClick = wireUpEventHandler(
       "onAutocompleteResultClick",
-      apiConnector!,
+      apiConnector,
       onAutocompleteResultClick
     );
     this.plugins = plugins;

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -9,7 +9,6 @@ import { mergeFilters } from "./helpers";
 import {
   AutocompleteResponseState,
   AutocompleteSearchQuery,
-  Filter,
   INVALID_CREDENTIALS,
   Plugin,
   QueryConfig,
@@ -78,7 +77,7 @@ export const DEFAULT_STATE: SearchState = {
 function removeConditionalFacets(
   facets = {},
   conditionalFacets = {},
-  filters: Filter[] | undefined = []
+  filters = []
 ) {
   return Object.entries(facets).reduce((acc, [facetKey, facet]) => {
     if (
@@ -172,7 +171,7 @@ class SearchDriver {
     apiConnector,
     autocompleteQuery = {},
     plugins = [],
-    debug = false,
+    debug,
     initialState,
     onSearch,
     onAutocomplete,
@@ -273,7 +272,7 @@ class SearchDriver {
     // Otherwise, we'll just save their selections in state as initial values.
     if (
       searchParameters.searchTerm ||
-      (searchParameters.filters?.length ?? 0) > 0 ||
+      searchParameters.filters.length > 0 ||
       this.alwaysSearchOnInitialLoad
     ) {
       this._updateSearchResults(searchParameters, { replaceUrl: true });
@@ -425,7 +424,7 @@ class SearchDriver {
         facets: removeConditionalFacets(
           this.searchQuery.facets,
           conditionalFacets,
-          filters as unknown as Filter[] | undefined
+          filters
         )
       };
 
@@ -442,8 +441,8 @@ class SearchDriver {
 
           this.events.emit({
             type: "SearchQuery",
-            filters: this.state.filters!,
-            query: this.state.searchTerm as string,
+            filters: this.state.filters,
+            query: this.state.searchTerm,
             currentPage: requestState.current,
             resultsPerPage: requestState.resultsPerPage,
             totalResults: totalResults
@@ -451,20 +450,18 @@ class SearchDriver {
 
           // Results paging start & end
           const start =
-            totalResults === 0 ? 0 : (current! - 1) * resultsPerPage! + 1;
+            totalResults === 0 ? 0 : (current - 1) * resultsPerPage + 1;
           const end =
-            totalResults < start + resultsPerPage!
+            totalResults < start + resultsPerPage
               ? totalResults
-              : start + resultsPerPage! - 1;
+              : start + resultsPerPage - 1;
 
           this._setState({
             isLoading: false,
             resultSearchTerm: searchTerm,
             pagingStart: start,
             pagingEnd: end,
-            // This overwrites prior terms :/
-            // So to suppress TS error cast as any
-            ...(resultState as any),
+            ...resultState,
             wasSearched: true
           });
 

--- a/packages/search-ui/src/URLManager.ts
+++ b/packages/search-ui/src/URLManager.ts
@@ -24,24 +24,20 @@ function toSingleValue(val): string {
   return Array.isArray(val) ? val[val.length - 1] : val;
 }
 
-function toSingleValueInteger(num): number | undefined {
+function toSingleValueInteger(num): number {
   return toInteger(toSingleValue(num));
 }
 
-function toInteger(num): number | undefined {
+function toInteger(num): number {
   if (!isNumericString(num)) return;
   return parseInt(num, 10);
 }
 
-function parseFiltersFromQueryParams(
-  queryParams: QueryParams
-): Filter[] | undefined {
+function parseFiltersFromQueryParams(queryParams: QueryParams): Filter[] {
   return queryParams.filters;
 }
 
-function parseCurrentFromQueryParams(
-  queryParams: QueryParams
-): number | undefined {
+function parseCurrentFromQueryParams(queryParams: QueryParams): number {
   return toSingleValueInteger(queryParams.current);
 }
 
@@ -59,14 +55,12 @@ function parseOldSortFromQueryParams(
   return [];
 }
 
-function parseSizeFromQueryParams(
-  queryParams: QueryParams
-): number | undefined {
+function parseSizeFromQueryParams(queryParams: QueryParams): number {
   return toSingleValueInteger(queryParams.size);
 }
 
 function parseSortFromQueryParams(queryParams: QueryParams): SortOption[] {
-  return queryParams["sort"]!;
+  return queryParams["sort"];
 }
 
 function paramsToState(queryParams: QueryParams): RequestState {
@@ -97,7 +91,7 @@ function stateToParams({
   sortList
 }: RequestState): QueryParams {
   const params: QueryParams = {};
-  if (current! > 1) params.current = current!;
+  if (current > 1) params.current = current;
   if (searchTerm) params.q = searchTerm;
   if (resultsPerPage) params.size = resultsPerPage;
   if (filters && filters.length > 0) {

--- a/packages/search-ui/src/URLManager.ts
+++ b/packages/search-ui/src/URLManager.ts
@@ -24,20 +24,24 @@ function toSingleValue(val): string {
   return Array.isArray(val) ? val[val.length - 1] : val;
 }
 
-function toSingleValueInteger(num): number {
+function toSingleValueInteger(num): number | undefined {
   return toInteger(toSingleValue(num));
 }
 
-function toInteger(num): number {
+function toInteger(num): number | undefined {
   if (!isNumericString(num)) return;
   return parseInt(num, 10);
 }
 
-function parseFiltersFromQueryParams(queryParams: QueryParams): Filter[] {
+function parseFiltersFromQueryParams(
+  queryParams: QueryParams
+): Filter[] | undefined {
   return queryParams.filters;
 }
 
-function parseCurrentFromQueryParams(queryParams: QueryParams): number {
+function parseCurrentFromQueryParams(
+  queryParams: QueryParams
+): number | undefined {
   return toSingleValueInteger(queryParams.current);
 }
 
@@ -55,12 +59,14 @@ function parseOldSortFromQueryParams(
   return [];
 }
 
-function parseSizeFromQueryParams(queryParams: QueryParams): number {
+function parseSizeFromQueryParams(
+  queryParams: QueryParams
+): number | undefined {
   return toSingleValueInteger(queryParams.size);
 }
 
 function parseSortFromQueryParams(queryParams: QueryParams): SortOption[] {
-  return queryParams["sort"];
+  return queryParams["sort"]!;
 }
 
 function paramsToState(queryParams: QueryParams): RequestState {
@@ -91,7 +97,7 @@ function stateToParams({
   sortList
 }: RequestState): QueryParams {
   const params: QueryParams = {};
-  if (current > 1) params.current = current;
+  if (current! > 1) params.current = current!;
   if (searchTerm) params.q = searchTerm;
   if (resultsPerPage) params.size = resultsPerPage;
   if (filters && filters.length > 0) {

--- a/packages/search-ui/src/actions/addFilter.ts
+++ b/packages/search-ui/src/actions/addFilter.ts
@@ -22,9 +22,9 @@ export default function addFilter(
   const { filters } = this.state as RequestState;
 
   const existingFilter =
-    filters.find((f) => f.field === name && f.type === type) || null;
+    filters?.find((f) => f.field === name && f.type === type) || null;
   const allOtherFilters =
-    filters.filter((f) => f.field !== name || f.type !== type) || [];
+    filters?.filter((f) => f.field !== name || f.type !== type) || [];
   const existingFilterValues = existingFilter?.values || [];
 
   const newFilterValues = existingFilterValues.find((existing) =>

--- a/packages/search-ui/src/actions/addFilter.ts
+++ b/packages/search-ui/src/actions/addFilter.ts
@@ -22,9 +22,9 @@ export default function addFilter(
   const { filters } = this.state as RequestState;
 
   const existingFilter =
-    filters?.find((f) => f.field === name && f.type === type) || null;
+    filters.find((f) => f.field === name && f.type === type) || null;
   const allOtherFilters =
-    filters?.filter((f) => f.field !== name || f.type !== type) || [];
+    filters.filter((f) => f.field !== name || f.type !== type) || [];
   const existingFilterValues = existingFilter?.values || [];
 
   const newFilterValues = existingFilterValues.find((existing) =>

--- a/packages/search-ui/src/actions/removeFilter.ts
+++ b/packages/search-ui/src/actions/removeFilter.ts
@@ -20,7 +20,7 @@ export default function removeFilter(
     // eslint-disable-next-line no-console
     console.log("Search UI: Action", "removeFilter", ...arguments);
 
-  const { filters } = this.state as RequestState;
+  const { filters = [] } = this.state as RequestState;
 
   let updatedFilters = filters;
 
@@ -44,7 +44,7 @@ export default function removeFilter(
   events.emit({
     type: "FacetFilterRemoved",
     field: name,
-    value: value && serialiseFilter([value]),
+    value: (value && serialiseFilter([value])) as any,
     query: this.state.searchTerm
   });
 }

--- a/packages/search-ui/src/actions/removeFilter.ts
+++ b/packages/search-ui/src/actions/removeFilter.ts
@@ -20,7 +20,7 @@ export default function removeFilter(
     // eslint-disable-next-line no-console
     console.log("Search UI: Action", "removeFilter", ...arguments);
 
-  const { filters = [] } = this.state as RequestState;
+  const { filters } = this.state as RequestState;
 
   let updatedFilters = filters;
 
@@ -44,7 +44,7 @@ export default function removeFilter(
   events.emit({
     type: "FacetFilterRemoved",
     field: name,
-    value: (value && serialiseFilter([value])) as any,
+    value: value && serialiseFilter([value]),
     query: this.state.searchTerm
   });
 }

--- a/packages/search-ui/src/actions/setFilter.ts
+++ b/packages/search-ui/src/actions/setFilter.ts
@@ -19,7 +19,7 @@ export default function setFilter(
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "setFilter", ...arguments);
 
-  let { filters = [] } = this.state as RequestState;
+  let { filters } = this.state as RequestState;
   filters = filters.filter(
     (filter) => filter.field !== name || filter.type !== type
   );
@@ -41,7 +41,7 @@ export default function setFilter(
   events.emit({
     type: "FacetFilterSelected",
     field: name,
-    value: (value && serialiseFilter([value])) as any,
+    value: value && serialiseFilter([value]),
     query: this.state.searchTerm
   });
 }

--- a/packages/search-ui/src/actions/setFilter.ts
+++ b/packages/search-ui/src/actions/setFilter.ts
@@ -19,7 +19,7 @@ export default function setFilter(
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "setFilter", ...arguments);
 
-  let { filters } = this.state as RequestState;
+  let { filters = [] } = this.state as RequestState;
   filters = filters.filter(
     (filter) => filter.field !== name || filter.type !== type
   );
@@ -41,7 +41,7 @@ export default function setFilter(
   events.emit({
     type: "FacetFilterSelected",
     field: name,
-    value: value && serialiseFilter([value]),
+    value: (value && serialiseFilter([value])) as any,
     query: this.state.searchTerm
   });
 }

--- a/packages/search-ui/src/actions/setSort.ts
+++ b/packages/search-ui/src/actions/setSort.ts
@@ -14,7 +14,7 @@ export default function setSort(
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "setSort", ...arguments);
 
-  const update = {
+  const update: Record<string, any> = {
     current: 1,
     sortList: null,
     sortField: null,

--- a/packages/search-ui/src/actions/setSort.ts
+++ b/packages/search-ui/src/actions/setSort.ts
@@ -14,7 +14,7 @@ export default function setSort(
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "setSort", ...arguments);
 
-  const update: Record<string, any> = {
+  const update = {
     current: 1,
     sortList: null,
     sortField: null,

--- a/packages/search-ui/src/actions/trackClickThrough.ts
+++ b/packages/search-ui/src/actions/trackClickThrough.ts
@@ -25,7 +25,7 @@ export default function trackClickThrough(
     current,
     resultsPerPage,
     totalResults,
-    filters
+    filters = []
   }: SearchState = this.state;
 
   const resultIndexOnPage = results.findIndex(
@@ -48,7 +48,7 @@ export default function trackClickThrough(
   events.emit({
     type: "ResultSelected",
     documentId,
-    query: searchTerm,
+    query: searchTerm as any,
     origin: "results",
     position: resultIndexOnPage,
     tags,

--- a/packages/search-ui/src/actions/trackClickThrough.ts
+++ b/packages/search-ui/src/actions/trackClickThrough.ts
@@ -25,7 +25,7 @@ export default function trackClickThrough(
     current,
     resultsPerPage,
     totalResults,
-    filters = []
+    filters
   }: SearchState = this.state;
 
   const resultIndexOnPage = results.findIndex(
@@ -48,7 +48,7 @@ export default function trackClickThrough(
   events.emit({
     type: "ResultSelected",
     documentId,
-    query: searchTerm as any,
+    query: searchTerm,
     origin: "results",
     position: resultIndexOnPage,
     tags,

--- a/packages/search-ui/src/helpers.ts
+++ b/packages/search-ui/src/helpers.ts
@@ -14,7 +14,9 @@ export function findFilterValues(
   name: string,
   filterType: FilterType
 ): FilterValue[] {
-  const filter = filters.find((f) => f.field === name && f.type === filterType);
+  const filter = filters?.find(
+    (f) => f.field === name && f.type === filterType
+  );
   if (!filter) return [];
   return filter.values;
 }
@@ -32,7 +34,7 @@ export function removeSingleFilterValue(
   filters: Filter[],
   fieldName: string,
   value: FilterValue,
-  filterType: FilterType
+  filterType: FilterType | undefined
 ): Filter[] {
   return filters.reduce((acc, filter) => {
     const { field, values, type, ...rest } = filter;
@@ -41,7 +43,7 @@ export function removeSingleFilterValue(
         (filterValue) => !doFilterValuesMatch(filterValue, value)
       );
       if (updatedFilterValues.length > 0) {
-        return acc.concat({
+        return (acc as any[]).concat({
           field,
           values: updatedFilterValues,
           type,
@@ -51,7 +53,7 @@ export function removeSingleFilterValue(
         return acc;
       }
     }
-    return acc.concat(filter);
+    return acc.concat(filter as any);
   }, []);
 }
 

--- a/packages/search-ui/src/helpers.ts
+++ b/packages/search-ui/src/helpers.ts
@@ -14,9 +14,7 @@ export function findFilterValues(
   name: string,
   filterType: FilterType
 ): FilterValue[] {
-  const filter = filters?.find(
-    (f) => f.field === name && f.type === filterType
-  );
+  const filter = filters.find((f) => f.field === name && f.type === filterType);
   if (!filter) return [];
   return filter.values;
 }
@@ -34,7 +32,7 @@ export function removeSingleFilterValue(
   filters: Filter[],
   fieldName: string,
   value: FilterValue,
-  filterType: FilterType | undefined
+  filterType: FilterType
 ): Filter[] {
   return filters.reduce((acc, filter) => {
     const { field, values, type, ...rest } = filter;
@@ -43,7 +41,7 @@ export function removeSingleFilterValue(
         (filterValue) => !doFilterValuesMatch(filterValue, value)
       );
       if (updatedFilterValues.length > 0) {
-        return (acc as any[]).concat({
+        return acc.concat({
           field,
           values: updatedFilterValues,
           type,
@@ -53,7 +51,7 @@ export function removeSingleFilterValue(
         return acc;
       }
     }
-    return acc.concat(filter as any);
+    return acc.concat(filter);
   }, []);
 }
 


### PR DESCRIPTION
In Search UI, no first-hand support for `optionLabelsMap` – this adds that support a bit more formally to `BeaconFacet`, specifically in how we search (typically we don't consult the map in search, so if we search for states (but have state codes as data) and search for `Calif`, nothing would come up because we only have the two letter codes)